### PR TITLE
add publishConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "publishConfig": {
+    "registry": "https://artifactory.aws.wiley.com/artifactory/api/npm/npm/"
+  },
   "keywords": [
     "swagger",
     "openapi",


### PR DESCRIPTION
```
vnabatov@wwl-nb-24092019-i5 MINGW64 /c/projects/CCP-API (master)
$ npm i -g serve-rapidoc --registry https://artifactory.aws.wiley.com/artifactory/api/npm/npm/
npm ERR! code E404
npm ERR! 404 Not Found - GET https://artifactory.aws.wiley.com/artifactory/api/npm/npm/serve-rapidoc - not_found
npm ERR! 404
npm ERR! 404  'serve-rapidoc@latest' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\vnabatov\AppData\Roaming\npm-cache\_logs\2020-06-16T11_21_39_080Z-debug.log

vnabatov@wwl-nb-24092019-i5 MINGW64 /c/projects/CCP-API (master)
$ npm i -g serve-rapidoc --registry https://registry.npmjs.org/
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/serve-rapidoc - Not found
npm ERR! 404
npm ERR! 404  'serve-rapidoc@latest' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\vnabatov\AppData\Roaming\npm-cache\_logs\2020-06-16T11_21_53_975Z-debug.log
```
do we need to publish this model to Wiley Npm Registry or am I doing something wrong?